### PR TITLE
Run ExperimentOffline unless production

### DIFF
--- a/now.json
+++ b/now.json
@@ -8,5 +8,8 @@
       {"src": "^/static/(.*)", "dest": "/static/$1"},
       {"src": "/.*", "dest": "/index.html"}
     ],
-    "alias": "empathic.sandboxneu.com"
+    "alias": "empathic.sandboxneu.com",
+    "env": {
+        "NODE_ENV": "production"
+    }
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,14 +2,18 @@ import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import '../App.css';
 import ExperimentOnline from './ExperimentOnline';
+import ExperimentOffline from './ExperimentOffline';
 import AdminPanel from './AdminPanel';
+
+const PRODUCTION = process.env.NODE_ENV === 'production';
+const Experiment = PRODUCTION ? ExperimentOnline : ExperimentOffline;
 
 function AppRouter() {
   return (
     <Router>
       <div className="App">
         <Route path="/admin" exact component={AdminPanel} />
-        <Route path="/" exact component={ExperimentOnline} />
+        <Route path="/" exact component={Experiment} />
       </div>
     </Router>
   );

--- a/src/components/ExperimentOffline.js
+++ b/src/components/ExperimentOffline.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Experiment from './Experiment';
+import config from '../offlineConfig';
+
+function generateID() {
+  return Math.random().toString(36).substring(2, 12).toUpperCase();
+}
+
+/* In charge of talking to server */
+function ExperimentOffline() {
+  return (<Experiment {...config} completionID={generateID()} sendData={console.log} />);
+}
+
+export default ExperimentOffline;

--- a/src/offlineConfig.json
+++ b/src/offlineConfig.json
@@ -1,0 +1,38 @@
+{
+  "videoId": "314909286/3623e43bae",
+  "instructionScreens": [
+    "Welcome to the empathy study, and thanks for participating! On the following screen, you will see more instructions on what you will be asked to do.",
+    "In this study, you will be shown a video and asked a set of questions about the video. You can answer these questions at any point. To be shown the questions, just pause the video. Click next to continue to the experiment."
+  ],
+  "questions": [
+    {
+      "type": "mc",
+      "label": "Is this cool?",
+      "choices": [
+        "No",
+        "Yes",
+        "Somewhat"
+      ]
+    },
+    {
+      "type": "scale",
+      "label": "How cool?",
+      "choices": [
+        "Not at all cool",
+        "A little cool",
+        "Super cool",
+        "vvvv cool",
+        "yuck"
+      ]
+    },
+    {
+      "type": "open",
+      "label": "Other comments: "
+    },
+    {
+      "type": "grid",
+      "label": "Grid"
+    }
+  ],
+  "completionLink": "https://sandboxneu.com"
+}


### PR DESCRIPTION
Now, unless `NODE_ENV` environment variable is set to 'production' the experiment runs offline. It reads config from offlineConfig.json and just logs the collected data to the browser console. This way we don't have to worry about messing up the server config/data while Maria is using it.

The Admin Panel still runs online!

On Zeit, it runs in production, as normal.